### PR TITLE
Fix escaping in default timestamp template

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -48,7 +48,7 @@ const DEFAULT_SETTINGS: MediaNotesPluginSettings = {
 	timestampOffsetSeconds: 6,
 	backgroundColor: "#000000",
 	progressBarColor: "#FF0000",
-	timestampTemplate: "[{ts}]({link})\n",
+	timestampTemplate: "[{ts}]({link})\\n",
 	mediaData: {},
 };
 


### PR DESCRIPTION
The default timestamp template ends with a newline, but the `\n` is not visible in the settings.