### PR TITLE
Add additional characters to bookmarklet.js regex

### DIFF
--- a/src/bookmarklet.js
+++ b/src/bookmarklet.js
@@ -32,7 +32,7 @@ function createMediaNote() {
 }
 
 const makeObsidianFriendly = (title) => {
-	var replacedTitle = "Video. " + title.replace(/[:/\\^|#]/g, ".");
+	var replacedTitle = "Video. " + title.replace(/[:/\\^|#\?\*"<>]/g, ".");
 	return replacedTitle;
 };
 


### PR DESCRIPTION
The characters '?', '*', '"', '<', and '>' cannot be used in note titles and were missing from the replacement regex in the bookmarklet code.