### PR TITLE
Add setting to disable width cap in horizontal mode (+2 bugfixes)

### DIFF
--- a/src/components/media-frame.tsx
+++ b/src/components/media-frame.tsx
@@ -14,7 +14,8 @@ export const MediaFrame: React.FC<{
 	ytRef: React.RefObject<YouTube>;
 	initSeconds: number;
 	autoplay?: boolean;
-}> = ({ mediaLink, ytRef, initSeconds, autoplay }) => {
+	disableWidthLimit?: boolean;
+}> = ({ mediaLink, ytRef, initSeconds, autoplay, disableWidthLimit }) => {
 	const videoId = getVideoId(mediaLink);
 	if (!videoId) return null;
 	const opts: YouTubeProps["opts"] = {
@@ -95,7 +96,7 @@ export const MediaFrame: React.FC<{
 
 	return (
 		<div className="media-top-container">
-			<div className="media-container">
+			<div className={`media-container${disableWidthLimit ? " no-width-limit": ""}`}>
 				{/* @ts-ignore TS2607 */}
 				<YouTube
 					ref={ytRef}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -752,19 +752,5 @@ class SettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
-
-		new Setting(containerEl)
-			.setName("Disable width limit in horizontal split mode")
-			.setDesc(
-				"If enabled, in horizontal-split mode the video player will expand to the width of the pane"
-			)
-			.addToggle((val) =>
-				val
-					.setValue(this.plugin.settings.disableWidthLimit)
-					.onChange(async (value) => {
-						this.plugin.settings.disableWidthLimit = value;
-						await this.plugin.saveSettings();
-					})
-			);
 	}
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -134,7 +134,8 @@ export default class MediaNotesPlugin extends Plugin {
 
 	renderPlayerInView = (markdownView: MarkdownView) => {
 		// @ts-ignore TS2339
-		const frontmatter = (parseYaml(markdownView.rawFrontmatter) ??
+		const rawFrontmatter = markdownView.rawFrontmatter ?? "";
+		const frontmatter = (parseYaml(rawFrontmatter) ??
 			{}) as Record<string, string>;
 		// if there's a media_link
 		if (frontmatter && getMediaLinkFromFrontmatter(frontmatter)) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,6 +27,7 @@ export interface MediaNotesPluginSettings {
 	displayProgressBar: boolean;
 	displayTimestamp: boolean;
 	pauseOnTimestampInsert: boolean;
+	disableWidthLimit: boolean;
 	defaultSplitMode: "Horizontal" | "Vertical";
 	mediaData: {
 		[id: string]: {
@@ -43,6 +44,7 @@ const DEFAULT_SETTINGS: MediaNotesPluginSettings = {
 	horizontalPlayerWidth: 40,
 	defaultSplitMode: "Vertical",
 	pauseOnTimestampInsert: false,
+	disableWidthLimit: false,
 	displayProgressBar: true,
 	displayTimestamp: true,
 	timestampOffsetSeconds: 6,
@@ -210,6 +212,8 @@ export default class MediaNotesPlugin extends Plugin {
 				autoplay = true;
 			}
 
+			const disableWidthLimit = this.settings.disableWidthLimit;
+
 			const root = createRoot(div);
 			root.render(
 				<>
@@ -222,6 +226,7 @@ export default class MediaNotesPlugin extends Plugin {
 							ytRef={ytRef}
 							initSeconds={Math.round(initSeconds)}
 							autoplay={autoplay}
+							disableWidthLimit={disableWidthLimit}
 						/>
 					</AppProvider>
 				</>
@@ -728,6 +733,20 @@ class SettingsTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.pauseOnTimestampInsert)
 					.onChange(async (value) => {
 						this.plugin.settings.pauseOnTimestampInsert = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName("Disable width limit in horizontal split mode")
+			.setDesc(
+				"If enabled, in horizontal-split mode the video player will expand to the width of the pane"
+			)
+			.addToggle((val) =>
+				val
+					.setValue(this.plugin.settings.disableWidthLimit)
+					.onChange(async (value) => {
+						this.plugin.settings.disableWidthLimit = value;
 						await this.plugin.saveSettings();
 					})
 			);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -626,6 +626,21 @@ class SettingsTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Disable video width limit")
+			.setClass("subSettings")
+			.setDesc(
+				"If enabled, in horizontal split mode the video player will expand to the width of the pane."
+			)
+			.addToggle((val) =>
+				val
+					.setValue(this.plugin.settings.disableWidthLimit)
+					.onChange(async (value) => {
+						this.plugin.settings.disableWidthLimit = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
 			.setName("Player width (%) in vertical-split mode")
 			.setDesc(
 				"The width of the player as a percentage of the viewport in vertical-split mode."

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,10 @@ If your plugin does not need CSS, delete this file.
 	}
 }
 
+.media-container.no-width-limit {
+	max-width: none;
+}
+
 .media-container-parent-vertical .markdown-source-view {
 	flex-direction: row !important;
 }

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@ If your plugin does not need CSS, delete this file.
 .youtube-iframe {
 	height: 100%;
 	width: 100%;
+	overflow: clip;
 }
 
 .media-top-container {

--- a/styles.css
+++ b/styles.css
@@ -365,3 +365,7 @@ If your plugin does not need CSS, delete this file.
 	animation-iteration-count: infinite;
 	animation-timing-function: linear;
 }
+
+.subSettings {
+	margin-left: 40px;
+}


### PR DESCRIPTION
On large screens, the cap for player width only goes up to 950px. Increasing the height % for the horizontal player results in black bars on the top and bottom of the video and a much smaller player than could fit in the region. This change adds a setting to disable this limit and allow the video to take up as much horizontal space as needed to display at the chosen height (only limited by pane size).

Before:
![image](https://github.com/user-attachments/assets/acf290e8-a0d3-45b2-928d-a220148f72dc)

After:
![image](https://github.com/user-attachments/assets/50b9ac90-dfeb-4e9c-87b3-edddafac41d4)

Settings page:
![image](https://github.com/user-attachments/assets/5ecfdf18-f035-4f65-b670-8d1c58862e11)


Other bugfixes:

- Fixed an error when enabling the plugin for the first time (seems to happen when an open file already has `media_link` set) where it would crash and disable itself by giving a default for `markdownView.rawFrontmatter` before passing it to `parseYaml`
- Fixed a minor visual bug where (especially at high height %) the embed iframe and the content would have mismatched sizes, resulting in a pixel of spillover into the page

Issues addressed:
- #18 