### PR TITLE
fix: dynamically build timestamp regex from settings template to avoid false positives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "media-notes-plugin",
-	"version": "1.1.0",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "media-notes-plugin",
-			"version": "1.1.0",
+			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"jest": "^29.7.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -257,7 +257,10 @@ export default class MediaNotesPlugin extends Plugin {
 
 	async onload() {
 		this.registerEditorExtension([
-			createClickHandlerPlugin(this.handleTimestampClick),
+			createClickHandlerPlugin(
+				this.handleTimestampClick,
+				() => this.settings.timestampTemplate
+			),
 		]);
 		await this.loadSettings();
 

--- a/src/viewPlugin.ts
+++ b/src/viewPlugin.ts
@@ -3,6 +3,7 @@ import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 class ClickHandlerPlugin {
 	view: EditorView;
 	handleTimestampClick: (ts: string) => boolean | undefined;
+	getTimestampTemplate: () => string;
 
 	constructor(view: EditorView) {
 		this.view = view;
@@ -13,26 +14,39 @@ class ClickHandlerPlugin {
 		const element = event.target as HTMLElement;
 		if (element.matches("span.cm-link, span.cm-link *")) {
 			const textContent = element.textContent;
-			const timestampRegex = /^(\d+:)?[0-5]?\d:[0-5]\d$/;
 			if (!textContent) return;
-			if (timestampRegex.test(textContent)) {
-				const isHandled = this.handleTimestampClick(textContent);
+
+			// Extract template from settings
+			const template = this.getTimestampTemplate ? this.getTimestampTemplate() : "[{ts}]({link})";
+			const matchBracket = template.match(/\[(.*?)\]/);
+			const linkTextTemplate = matchBracket ? matchBracket[1] : "{ts}";
+			const parts = linkTextTemplate.split("{ts}");
+			const prefix = parts[0] || "";
+			const suffix = parts[1] || "";
+
+			// Escape prefix and suffix for regex
+			const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			const escapedPrefix = escapeRegExp(prefix);
+			const escapedSuffix = escapeRegExp(suffix);
+
+			const timestampRegex = new RegExp("^" + escapedPrefix + "((\\d+:)?[0-5]?\\d:[0-5]\\d)" + escapedSuffix + "$");
+			const match = textContent.match(timestampRegex);
+			if (match) {
+				const cleanTimestamp = match[1];
+				const isHandled = this.handleTimestampClick(cleanTimestamp);
 				if (isHandled) {
 					event.preventDefault();
 					event.stopPropagation();
 				}
 			}
-			// Add your custom logic here
 		}
 	};
 
 	update(update: ViewUpdate) {
 		update.view.dom.addEventListener("click", this.handleClick);
-		// This method is called whenever the view is updated
 	}
 
 	destroy() {
-		// This method is called when the plugin is no longer needed
 		this.view.dom.removeEventListener("click", this.handleClick);
 	}
 }
@@ -40,13 +54,15 @@ class ClickHandlerPlugin {
 export const clickHandlerPlugin = ViewPlugin.fromClass(ClickHandlerPlugin);
 
 export function createClickHandlerPlugin(
-	handleTimestampClick: (ts: string) => boolean | undefined
+	handleTimestampClick: (ts: string) => boolean | undefined,
+	getTimestampTemplate: () => string
 ) {
 	return ViewPlugin.fromClass(
 		class extends ClickHandlerPlugin {
 			constructor(view: EditorView) {
 				super(view);
 				this.handleTimestampClick = handleTimestampClick;
+				this.getTimestampTemplate = getTimestampTemplate;
 			}
 		}
 	);


### PR DESCRIPTION
Currently, the plugin uses a strict hardcoded regex to match timestamp links inside the CodeMirror editor view. This breaks if a user customizes their timestamp template in settings (for example, wrapping it in parentheses like `[({ts})]`).

This PR addresses this by dynamically constructing the exact regex pattern at runtime based on the prefix and suffix defined around the `{ts}` variable in the user's `timestampTemplate` setting.

This ensures that:
1. Formatted timestamps (like `(27:49)`) are perfectly matched and their numeric parts are cleanly extracted.
2. Standard links containing similar numbers (e.g. `[Meeting at 12:34](https://...)`) do NOT trigger false positives, preserving standard click behaviors.